### PR TITLE
Added OS prep script for Ubuntu, modified directory structure

### DIFF
--- a/os/osx/osxprep.sh
+++ b/os/osx/osxprep.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Ask for the administrator password upfront
+sudo -v
+
+# Keep-alive: update existing `sudo` time stamp until `osxprep.sh` has finished
+while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+
+# Step 1: Update the OS and Install Xcode Tools
+echo "------------------------------"
+echo "Updating OSX.  If this requires a restart, run the script again."
+# Install all available updates
+sudo softwareupdate -ia --verbose
+# Install only recommended available updates
+#sudo softwareupdate -ir --verbose
+
+echo "------------------------------"
+echo "Installing Xcode Command Line Tools."
+# Install Xcode command line tools
+xcode-select --install
+
+# Keep-alive: update existing `sudo` time stamp until the script has finished.
+while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+
+# Check for Homebrew,
+# Install if we don't have it
+if test ! $(which brew); then
+  echo "Installing homebrew..."
+  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+fi
+
+# Make sure we’re using the latest Homebrew.
+brew update
+
+# Upgrade any already-installed formulae.
+brew upgrade --all
+
+# Install GNU core utilities (those that come with OS X are outdated).
+# Don’t forget to add `$(brew --prefix coreutils)/libexec/gnubin` to `$PATH`.
+brew install coreutils
+sudo ln -s /usr/local/bin/gsha256sum /usr/local/bin/sha256sum
+
+# Install `wget` with IRI support.
+brew install wget --with-iri
+
+# Install more recent versions of some OS X tools.
+brew install vim --override-system-vi
+brew install homebrew/dupes/grep
+brew install homebrew/dupes/openssh
+brew install homebrew/dupes/screen
+brew install homebrew/php/php55 --with-gmp
+
+# Install developer friendly quick look plugins; see https://github.com/sindresorhus/quick-look-plugins
+brew cask install qlcolorcode qlstephen qlmarkdown quicklook-json qlprettypatch quicklook-csv betterzip qlimagesize webpquicklook suspicious-package quicklookase qlvideo
+
+# Install Heroku
+brew install heroku/brew/heroku
+heroku update
+
+# Core casks
+brew cask install --appdir="/Applications" alfred
+brew cask install --appdir="~/Applications" iterm2
+brew cask install --appdir="~/Applications" java
+brew cask install --appdir="~/Applications" xquartz
+
+# Development tool casks
+brew cask install --appdir="/Applications" sublime-text
+brew cask install --appdir="/Applications" atom
+brew cask install --appdir="/Applications" virtualbox
+brew cask install --appdir="/Applications" vagrant
+brew cask install --appdir="/Applications" macdown
+
+# Remove outdated versions from the cellar.
+brew cleanup

--- a/os/ubuntu/ubuntuprep.sh
+++ b/os/ubuntu/ubuntuprep.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Exit on any failure
+set -e
+
+# Update package lists
+echo "# Updating package lists"
+sudo apt-add-repository -y ppa:git-core/ppa
+sudo apt-get update
+
+# Check for wget,
+# Install if we don't have it
+if [ ! -x /usr/bin/wget ]; then
+    sudo apt-get install wget
+fi
+
+# Check for curl,
+# Install if we don't have it
+if [ ! -x /usr/bin/curl ]; then
+    sudo apt-get install curl
+fi
+
+# Installing additional packages
+sudo apt install -y apt-transport-https ca-certificates curl software-properties-common
+
+# Installing Git
+sudo apt-get install -y git
+
+# Installing Docker
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
+sudo apt-get update
+sudo apt-cache policy docker-ce
+sudo apt-get -y install docker-ce
+sudo usermod -aG docker ${USER}
+
+# Installing Vim, openssh, php, heroku, virtualbox
+sudo apt-get install vim -y
+sudo apt install --assume-yes openssh-server -y
+sudo add-apt-repository ppa:ondrej/php -y
+sudo wget -qO- https://toolbelt.heroku.com/install-ubuntu.sh | sh
+sudo apt-get install virtualbox -y
+
+# Installing Java
+sudo apt-get install default-jre -y
+sudo apt-get install default-jdk -y
+
+# Installing Sublime Text3
+sudo add-apt-repository ppa:webupd8team/sublime-text-3 -y
+sudo apt-get install sublime-text-installer -y
+
+# Installing Atom
+sudo apt install software-properties-common apt-transport-https wget -y
+wget -q https://packagecloud.io/AtomEditor/atom/gpgkey -O- | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://packagecloud.io/AtomEditor/atom/any/ any main"
+sudo apt install atom -y
+sudo apt install virtualbox -y


### PR DESCRIPTION
I have added in OS prep script for Ubuntu (Hurray !), which will install the following developer tools and applications.
Made assumptions about the developer tools and applications that we would need based on the pre-existing script `osxprep.sh`
- git
- curl
- wget
- docker
- vim
- openssh
- php
- heroku
- virtualbox
- java
- sublime-text-3
- atom

The modifications to the directory structure are made so that we could have more OS prep scripts added in the nearby awesome future. Do let me know your thoughts on them.